### PR TITLE
Add jenkins user to docker group instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ RUN apt-get update \
     && apt-get install -y docker-ce \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* 
-RUN usermod -aG root jenkins 
+RUN usermod -aG docker jenkins 
 USER jenkins


### PR DESCRIPTION
When executing, for example, 'docker version', from within a free-style jenkins project, I got permission denied messages. After adding the jenkins user to the docker group and rebuilding the image, it worked flawlessly.