### PR TITLE
Add dokcer tags other than the lts #6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+jenkins_home
+example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/jenkins:lts
+ARG tag=${DOCKER_TAG:-lts}
+FROM jenkins/jenkins:${tag}
 
 USER root
 RUN apt-get update \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,8 @@
+ARG tag=${DOCKER_TAG:-lts-alpine}
+FROM jenkins/jenkins:${tag}
+
+USER root
+RUN apk update \
+    && apk add --no-cache docker
+RUN addgroup -S jenkins docker
+USER jenkins

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for example...
 - build docker images
 - push your docker image
 
-This dockerfile is based on [jenkins/jenkins](https://hub.docker.com/r/jenkins/jenkins/) and install Docker CE with [Docker install Guild](https://docs.docker.com/engine/installation/linux/docker-ce/debian/).
+This dockerfile is based on [jenkins/jenkins](https://hub.docker.com/r/jenkins/jenkins/) and install Docker CE with [Docker install Guide](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) or [Alpine Linux Wiki](https://wiki.alpinelinux.org/wiki/Docker#Installation).
 
 ## Getting Started
 ### 1. Pull or Build docker image


### PR DESCRIPTION
Change/Add Dockerfile to add dokcer tags other than the lts.

- Add docker build-arg variable `tag`.
- Add `Dockefile-alpine` to build docker images based on Alpine Linux.
